### PR TITLE
Fix functional Geb-Tests

### DIFF
--- a/src/integration-test/groovy/trip/planner/HomeFunctionalSpec.groovy
+++ b/src/integration-test/groovy/trip/planner/HomeFunctionalSpec.groovy
@@ -55,25 +55,23 @@ class HomeFunctionalSpec extends GebSpec {
         when: "Valid cities are given"
         HomePage page = browser.to HomePage
         page.enterCity(page.startSearchField, LEIPZIG)
-        page.clickFirstAutocomplete(page.startDropdown)
         page.enterCity(page.destinationSearchField, BERLIN)
-        page.clickFirstAutocomplete(page.destinationDropdown)
         page.submitButton.click()
 
         then: "spinner stops spinning"
-        assert waitFor(wait: 150){!page.spinnerExists()}
+        assert waitFor(155){
+            !page.spinnerExists()
+        }
     }
 
     void "test generate route no route exists"() {
         when: "Unconnectable cities are given"
         HomePage page = browser.to HomePage
         page.enterCity(page.startSearchField, LEIPZIG)
-        page.clickFirstAutocomplete(page.startDropdown)
         page.enterCity(page.destinationSearchField, NEW_YORK)
-        page.clickFirstAutocomplete(page.destinationDropdown)
 
         then: "Alert occurs"
-        withAlert(wait: true) {
+        withAlert(wait: 151) {
             page.submitButton.click()
         }
     }

--- a/src/integration-test/groovy/trip/planner/HomePage.groovy
+++ b/src/integration-test/groovy/trip/planner/HomePage.groovy
@@ -34,11 +34,6 @@ class HomePage extends Page {
         autoComplNav.children()*.text()
     }
 
-    void clickFirstAutocomplete(Navigator autoComplNav){
-        waitFor(10) { autoComplNav.displayed }
-        autoComplNav.click()
-    }
-
     boolean spinnerExists() {
         spinner
     }


### PR DESCRIPTION
this closes #61 

Because the order of the test-execution is relevant, the test "test generate route no route exists" fails too.

The fix of "test generate route spinner stops spinning" fixes both tests (when you execute all tests in the given order^^). 